### PR TITLE
Added howto contribute description to Teams and Publication

### DIFF
--- a/about.rst
+++ b/about.rst
@@ -1,7 +1,7 @@
-.. _intersect:arch:team:
+.. _intersect:arch:about:
 
-Team and Publications
-#####################
+About
+#####
 
 The :term:`INTERconnected Science ECosysTem (INTERSECT)<INTERSECT>` open
 federated hardware/software architecture is currently being developed at

--- a/index.rst
+++ b/index.rst
@@ -12,7 +12,7 @@ INTERSECT Architecture Documentation
 
    introduction
    concept
-   team
+   about
 
 .. toctree::
    :maxdepth: 2

--- a/team.rst
+++ b/team.rst
@@ -71,6 +71,14 @@ INTERSECT Architecture Documentation.
 URL: https://intersect-architecture.readthedocs.io
 
 
+.. _intersect:arch:team:contribute:
+
+.. rubric:: How to Contribute to this Documentation
+
+This documentation is maintaned on GitHub. To contribute, please go to
+https://github.com/ORNL/intersect-architecture.
+
+
 .. _intersect:arch:team:publications:
 
 .. rubric:: Publications


### PR DESCRIPTION
For consistency and to link the GitHub repository, I added a howto contribute description to the Teams and Publication section.