### PR TITLE
Various Corrections in the Science Use Case Design Patterns

### DIFF
--- a/concept.rst
+++ b/concept.rst
@@ -8,8 +8,8 @@ The :term:`INTERSECT` open architecture approach roughly follows the
 :cite:`DoDAF2:2010` with its different architectural viewpoints, such as (i)
 operational scenarios, (ii) composition, interconnectivity and context, (iii)
 services and their capabilities, (iv) policies, standards and guidance, and (v)
-capability. The major difference is that the :term:`INTERSECT` Open
-Architecture splits these views over three different components
+capability. The major difference is that the :term:`INTERSECT` open
+architecture splits these views over three different components
 (:numref:`intersect:arch:concept:architecture`): (1) :ref:`intersect:arch:pat`,
 (2) a :ref:`intersect:arch:sos`, and (3) a :ref:`intersect:arch:ms`:
 
@@ -18,7 +18,7 @@ Architecture splits these views over three different components
    :term:`AI`-driven design, discovery and evaluation are described as
    :ref:`intersect:arch:pat` that identify and abstract the involved
    hardware/software components and their interactions in terms of control,
-   work, and data flow. The basic template for a science use case design
+   work and data flow. The basic template for a science use case design
    pattern is defined in a loop control problem paradigm. There are two classes
    in the :ref:`intersect:arch:pat:catalog`: strategic patterns and
    architectural patterns. :ref:`intersect:arch:pat:catalog:strategic` define
@@ -49,13 +49,20 @@ Architecture splits these views over three different components
    systems, geographical distribution with a physically distributed and
    federated ecosystem, emergent behavior based on the interplay between
    systems and components, and evolutionary development through pluggability
-   and extensibility.
+   and extensibility. Similar to the :term:`DoDAF`, the
+   :ref:`intersect:arch:sos` offers different architectural viewpoints: a
+   :ref:`intersect:arch:sos:logical`, an :ref:`intersect:arch:sos:operational`
+   a :ref:`intersect:arch:sos:user`, a :ref:`intersect:arch:sos:data`, a
+   :ref:`intersect:arch:sos:physical`, and a
+   :ref:`intersect:arch:sos:standards`.
 
 :ref:`intersect:arch:ms`
    The :ref:`intersect:arch:ms` maps the :ref:`intersect:arch:pat` to
    the :ref:`intersect:arch:sos` with loosely coupled microservices and
-   standardized interfaces. It provides a catalog of infrastructure and
-   experiment-specific microservices. The microservices are defined to
+   standardized interfaces. It defines :ref:`intersect:arch:ms:interactions`
+   and provides a :ref:`intersect:arch:ms:class` that includes
+   :ref:`intersect:arch:ms:class:infrastructure` and
+   :ref:`intersect:arch:ms:class:experiment`. The microservices are defined to
    facilitate composition within the federated :ref:`intersect:arch:sos`.
    :term:`INTERSECT` infrastructure microservices represent common service
    functionality and capabilities, such as data management, computing,
@@ -65,6 +72,9 @@ Architecture splits these views over three different components
    whose implementation may require detailed application knowledge, such as
    experiment planning or steering services that require knowledge of
    experiment-specific control parameters and their associated constraints.
+   The :ref:`intersect:arch:ms` also clarifies
+   :ref:`intersect:arch:ms:orchestration` and
+   :ref:`intersect:arch:ms:deployment`.
 
 .. figure:: concept/architecture.png
    :name: intersect:arch:concept:architecture
@@ -72,7 +82,7 @@ Architecture splits these views over three different components
    :width: 800
 
    Components of the :term:`INTERSECT` architecture in the context of the
-   :term:`INTERSECT` Initiative activities.
+   :term:`INTERSECT` Initiative's activities.
 
 This approach permits separating (a) coarse-grain architectural decisions, such
 as what objective a particular self-driving laboratory has and how that
@@ -83,9 +93,7 @@ self-driving laboratory and how do they communicate with each other, and from
 control, data transfer and compute microservices are being used and how. The
 :ref:`intersect:arch:pat`, :ref:`intersect:arch:sos`, and
 :ref:`intersect:arch:ms` complement each other, just like the different
-viewpoints of the :term:`DoDAF`. Additionally, the :ref:`intersect:arch:sos`
-itself offers complementary viewpoints, such as user, data, operational,
-logical, physical, and standards view. :ref:`intersect:arch:examples` describe
+viewpoints of the :term:`DoDAF`. :ref:`intersect:arch:examples` describe
 how each of these architecture components is applied to real-world use cases.
 The :term:`DOE`\ 's recent efforts in an :ref:`intersect:arch:iri` are
 addressed as well, specifically the the relationships between its

--- a/concept.rst
+++ b/concept.rst
@@ -59,7 +59,7 @@ architecture splits these views over three different components
 :ref:`intersect:arch:ms`
    The :ref:`intersect:arch:ms` maps the :ref:`intersect:arch:pat` to
    the :ref:`intersect:arch:sos` with loosely coupled microservices and
-   standardized interfaces. It defines :ref:`intersect:arch:ms:interactions`
+   uniform interfaces. It defines :ref:`intersect:arch:ms:interactions`
    and provides a :ref:`intersect:arch:ms:class` that includes
    :ref:`intersect:arch:ms:class:infrastructure` and
    :ref:`intersect:arch:ms:class:experiment`. The microservices are defined to

--- a/examples/aam/index.rst
+++ b/examples/aam/index.rst
@@ -34,13 +34,11 @@ targets :term:`AM` builds with residual stress at least two times closer to the
 desired distribution than current methods, drastically reducing the time to
 develop process parameters for new alloys and geometries.
 
-.. list-table::
+.. youtube:: UGTADFR1O2U
    :align: center
+   :width: 600
 
-   * -
-      .. youtube:: UGTADFR1O2U
-         :align: center
-         :width: 800
+|
 
 The :term:`AAM` system is deployed at :term:`Oak Ridge National Laboratory's
 (ORNL's) <ORNL>` :term:`Manufacturing Demonstration Facility (MDF)<MDF>`,

--- a/examples/index.rst
+++ b/examples/index.rst
@@ -9,18 +9,18 @@ edge/center computing/data resources to enable autonomous experiments,
 self-driving laboratories, smart manufacturing, and :term:`AI`-driven design,
 discovery and evaluation. It consists of:
 
-#. :ref:`intersect:arch:pat` that identify and abstract the involved
-   hardware/software components and their interactions in terms of control,
-   work and data flow.
+- :ref:`intersect:arch:pat` that identify and abstract the involved
+  hardware/software components and their interactions in terms of control,
+  work and data flow.
 
-#. A :ref:`intersect:arch:sos` of the federated hardware/software ecosystem
-   that clarifies terms, architectural elements, the interactions between them,
-   and compliance.
+- A :ref:`intersect:arch:sos` of the federated hardware/software ecosystem
+  that clarifies terms, architectural elements, the interactions between them,
+  and compliance.
 
-#. A federated :ref:`intersect:arch:ms` that maps science use case design
-   patterns to the :ref:`intersect:arch:sos` with loosely coupled
-   microservices, standardized interfaces, and multi programming language
-   support.
+- A federated :ref:`intersect:arch:ms` that maps science use case design
+  patterns to the :ref:`intersect:arch:sos` with loosely coupled
+  microservices, standardized interfaces, and multi programming language
+  support.
 
 It covers a wide variety of interconnected science use cases through proper
 abstractions and composability. This Section describes how individual science

--- a/introduction.rst
+++ b/introduction.rst
@@ -25,8 +25,8 @@ ongoing or plan a next experiment. It may be assisted by an :term:`AI` that is
 trained online and/or offline with archived data and/or with synthetic data
 created by a digital twin. Analysis and decision making may also rely on
 rule-based approaches, causal or physics-based models, and advanced statistical
-methods. Human interaction for experiment planning, observation and steering is
-performed through appropriate human-machine interfaces.
+methods. Human interaction for experiment planning, observation, and steering
+is performed through appropriate human-machine interfaces.
 
 For example, both the rate and output of traditional materials synthesis and
 discovery are currently too slow and too small to efficiently provide needed
@@ -81,10 +81,8 @@ discovery and evaluation. :ref:`intersect:arch:examples` offer insight for
 applying this novel approach to real-world solutions. The :term:`DOE`\ 's
 recent efforts in an :ref:`intersect:arch:iri` are addressed as well.
 
-.. list-table::
+.. youtube:: MQImdRf5wfc
    :align: center
+   :width: 600
 
-   * -
-      .. youtube:: MQImdRf5wfc
-         :align: center
-         :width: 800
+|

--- a/iri/patterns/index.rst
+++ b/iri/patterns/index.rst
@@ -25,7 +25,7 @@ The :term:`IRI` patterns are very good examples of
 related to the :term:`INTERSECT` architecture and ecosystem, which address a
 number :term:`IRI` practice areas and patterns. The :term:`IRI` patterns are
 not defined in a very formal way with a specific pattern anatomy and format in
-mind, but are rather as structured informal descriptions of the commonalities,
+mind, but are structured as informal descriptions of the commonalities,
 requirements, and challenges for each pattern. Their relationships to the
 :term:`INTERSECT` :ref:`intersect:arch:pat` are similarly discussed in a
 structured informal fashion.

--- a/ms/orchestration/index.rst
+++ b/ms/orchestration/index.rst
@@ -1,4 +1,4 @@
-.. _intersect:arch:ms:orchestrate:
+.. _intersect:arch:ms:orchestration:
 
 Orchestration of INTERSECT Microservices
 ########################################

--- a/ms/orchestration/ms-orchestrate-patterns.rst
+++ b/ms/orchestration/ms-orchestrate-patterns.rst
@@ -1,5 +1,5 @@
 
-.. _intersect:arch:ms:orchestrate:patterns:
+.. _intersect:arch:ms:orchestration:patterns:
 
 Orchestration Patterns for Microservices
 ========================================

--- a/ms/orchestration/patterns/conductor-choreography.rst
+++ b/ms/orchestration/patterns/conductor-choreography.rst
@@ -1,4 +1,4 @@
-.. _intersect:arch:ms:orchestrate:patterns:choreography:
+.. _intersect:arch:ms:orchestration:patterns:choreography:
 
 Conductor vs. Choreography
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ms/orchestration/patterns/retry-recovery.rst
+++ b/ms/orchestration/patterns/retry-recovery.rst
@@ -1,4 +1,4 @@
-.. _intersect:arch:ms:orchestrate:patterns:retry_recovery:
+.. _intersect:arch:ms:orchestration:patterns:retry_recovery:
 
 Retry and Recovery from Errors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pat/anatomy.rst
+++ b/pat/anatomy.rst
@@ -16,14 +16,14 @@ experiments in an open or closed loop control. Such an abstract
 definition creates universal patterns that describe solutions free of
 implementation details.
 
-:ref:`intersect:arch:pat:anatomy:experiment` and
-:ref:`intersect:arch:pat:anatomy:workflow` show two different
-loop control problems. :ref:`intersect:arch:pat:anatomy:experiment`
+:numref:`intersect:arch:pat:anatomy:experiment` and
+:numref:`intersect:arch:pat:anatomy:workflow` show two different
+loop control problems. :numref:`intersect:arch:pat:anatomy:experiment`
 describes a closed loop control of an experiment that performs a test with
 some feedback to an experiment controller running the test.
-:ref:`intersect:arch:pat:anatomy:workflow` describes a
+:numref:`intersect:arch:pat:anatomy:workflow` describes a
 multi-experiment workflow with a closed loop control of multiple experiments,
-each with their own a closed loop control. There are a number of different
+each with their own closed loop control. There are a number of different
 loop control problems that the science use case design patterns systematize
 and categorize.
 

--- a/pat/catalog/architectural/index.rst
+++ b/pat/catalog/architectural/index.rst
@@ -17,36 +17,36 @@ workflow, such as using experiment-local, edge and/or center computing and data
 resources. The :ref:`intersect:arch:pat:catalog:architectural:toc` defines the
 following architectural patterns:
 
--  :ref:`intersect:arch:pat:catalog:architectural:local_control`: A local
-   experiment controller executes an experiment. There are no remote components
-   that could incur a significant communication delay.
+:ref:`intersect:arch:pat:catalog:architectural:local_control`
+   A local experiment controller executes an experiment. There are no remote
+   components that could incur a significant communication delay.
 
--  :ref:`intersect:arch:pat:catalog:architectural:distributed_control`: A remote
-   experiment controller executes an experiment, incurring a potentially
-   significant communication delay.
+:ref:`intersect:arch:pat:catalog:architectural:distributed_control`
+   A remote experiment controller executes an experiment, incurring a
+   potentially significant communication delay.
 
--  :ref:`intersect:arch:pat:catalog:architectural:local_steering`: Experiment
-   progress is analyzed and judged locally. There are no remote components that
-   could incur a significant communication delay.
+:ref:`intersect:arch:pat:catalog:architectural:local_steering`
+   Experiment progress is analyzed and judged locally. There are no remote
+   components that could incur a significant communication delay.
 
--  :ref:`intersect:arch:pat:catalog:architectural:distributed_steering`:
+:ref:`intersect:arch:pat:catalog:architectural:distributed_steering`
    Experiment progress is analyzed and optionally also judged/controlled
    remotely, incurring a potentially significant communication delay.
 
--  :ref:`intersect:arch:pat:catalog:architectural:local_design`: Experiment
-   results are analyzed and judged locally. There are no remote components that
-   could incur a significant communication delay.
+:ref:`intersect:arch:pat:catalog:architectural:local_design`
+   Experiment results are analyzed and judged locally. There are no remote
+   components that could incur a significant communication delay.
 
--  :ref:`intersect:arch:pat:catalog:architectural:distributed_design`:
+:ref:`intersect:arch:pat:catalog:architectural:distributed_design`
    Experiment results are analyzed and optionally also judged/controlled
    remotely, incurring a potentially significant communication delay.
 
--  :ref:`intersect:arch:pat:catalog:architectural:local_workflow`: All
-   experiments are local. There are no remote experiments that could incur a
-   significant communication delay.
+:ref:`intersect:arch:pat:catalog:architectural:local_workflow`
+   All experiments are local. There are no remote experiments that could incur
+   a significant communication delay.
 
--  :ref:`intersect:arch:pat:catalog:architectural:distributed_workflow`: One or
-   more experiments are remote, incurring a potentially significant
+:ref:`intersect:arch:pat:catalog:architectural:distributed_workflow`
+   One or more experiments are remote, incurring a potentially significant
    communication delay.
 
 :numref:`intersect:arch:pat:catalog:architectural:relationships` shows the

--- a/pat/catalog/index.rst
+++ b/pat/catalog/index.rst
@@ -14,8 +14,7 @@ individual pattern capabilities and relationships. It also further helps to
 understand how patterns rely on each other and can be composed to form a
 complete solution.
 
-The classification of science use case design patterns is work in progress at
-this stage of this document. At this point, there are two classes of science use
+There are currently two classes of science use
 case design patterns (:numref:`intersect:arch:pat:catalog:classification`): (1)
 :ref:`intersect:arch:pat:catalog:strategic` that define high-level solution
 methods using experiment control architecture features at a very coarse
@@ -46,7 +45,7 @@ The primary feature currently explored by the
 and remote components used by a corresponding strategic pattern, where local
 means that there is not a potentially significant communication delay to a
 component and remote means that there is a potentially significant communication
-delay to a component. Other architectural features may be explored in the future
+delay. Other architectural features may be explored in the future
 with different patterns.
 
 For example, the :ref:`intersect:arch:pat:catalog:strategic:steering` strategic
@@ -70,11 +69,15 @@ This classification scheme is open for extension. New patterns may be added for
 each class if new strategic or architectural patterns emerge that do not fit in
 the existing patterns. New classes may be added if new pattern features emerge
 that express commonalities that are not covered by patterns. For example, a new
-class may map the existing patterns to data-intensive, time-sensitive an
-long-term experiment campaigns, which are workflow execution features that are
+class may map the existing patterns to the
+:ref:`intersect:arch:iri:patterns:time`,
+:ref:`intersect:arch:iri:patterns:data` and
+:ref:`intersect:arch:iri:patterns:long` patterns of the
+:ref:`intersect:arch:iri` Blueprint Activity, which are
+:ref:`intersect:arch:sos:logical:systems:ors:workflows:pattern` that are
 orthogonal to the current pattern classes. Another new class may focus on the
-algorithms used in the feedback loop, such as probabilistic (e.g.,
-Bayesian) vs. domain science based (e.g., physics informed) algorithms.
+algorithms used in the feedback loop, such as probabilistic (e.g., Bayesian) vs.
+domain science based (e.g., physics informed) algorithms.
 
 .. toctree::
    :maxdepth: 2

--- a/pat/catalog/strategic/index.rst
+++ b/pat/catalog/strategic/index.rst
@@ -10,46 +10,48 @@ about the overall organization of the used techniques and their implications on
 the full system design. The :ref:`intersect:arch:pat:catalog:strategic:toc`
 defines the following strategic patterns:
 
--  :ref:`intersect:arch:pat:catalog:strategic:control`: Certain predetermined
-   actions need to be performed while running an experiment. This pattern would
-   be used in all automated experiments that do not have feedback for steering
-   the ongoing or designing the next experiment. Since autonomous operation
-   requires to first figure out automation, this pattern provides a basic
-   solution that covers most experiments performed at this point.
+:ref:`intersect:arch:pat:catalog:strategic:control`
+   Certain predetermined actions need to be performed while running an
+   experiment. This pattern would be used in all automated experiments that do
+   not have feedback for steering the ongoing or designing the next experiment.
+   Since autonomous operation requires to first figure out automation, this
+   pattern provides a basic solution that covers most experiments performed at
+   this point.
 
--  :ref:`intersect:arch:pat:catalog:strategic:steering`: Certain predetermined
-   actions need to be performed while running an experiment to positively
-   influence experiment progress. This pattern involves feedback for the ongoing
-   experiment as an extension to
+:ref:`intersect:arch:pat:catalog:strategic:steering`
+   Certain predetermined actions need to be performed while running an
+   experiment to positively influence experiment progress. This pattern
+   involves feedback for the ongoing experiment as an extension to
    :ref:`intersect:arch:pat:catalog:strategic:control`. It offers autonomous
    operation and is used in experiments that require live feedback to adjust
    parameters.
 
--  :ref:`intersect:arch:pat:catalog:strategic:design`: Certain predetermined
-   actions need to be performed to run a set of similar experiments with
-   different experiment plan parameters, depending on (prior) experiment
-   results. This pattern makes use of either
+:ref:`intersect:arch:pat:catalog:strategic:design`
+   Certain predetermined actions need to be performed to run a set of similar
+   experiments with different experiment plan parameters, depending on (prior)
+   experiment results. This pattern makes use of either
    :ref:`intersect:arch:pat:catalog:strategic:control` or
    :ref:`intersect:arch:pat:catalog:strategic:steering` and additionally offers
    feedback between experiments, typically to define the parameters of the next
-   experiment or next series of experiments. It is typically used in conjunction
-   with probabilistic (e.g., Bayesian) or domain science based (e.g., physics
-   informed) analysis of experiment results. This pattern is predominantly used
-   in large-scale parameter studies, such as to find the optimal conditions of a
-   chemical catalysis.
+   experiment or next series of experiments. It is typically used in
+   conjunction with probabilistic (e.g., Bayesian) or domain science based
+   (e.g., physics informed) analysis of experiment results. This pattern is
+   predominantly used in large-scale parameter studies, such as to find the
+   optimal conditions of a chemical catalysis.
 
--  :ref:`intersect:arch:pat:catalog:strategic:workflow`: Certain predetermined
-   actions need to be performed to run a set of experiments in serial (one after
-   another) and/or in parallel (simultaneously). This pattern utilizes the other
-   3 patterns to orchestrate multiple experiments that may depend on each other.
-   An example use case is the creation of a certain material using physical
-   and/or chemical processes (e.g., catalysis) and the analysis of the
-   properties of the created material in multiple experiments (e.g.,
-   spectroscopy and stress testing).
+:ref:`intersect:arch:pat:catalog:strategic:workflow`
+   Certain predetermined actions need to be performed to run a set of
+   experiments in serial (one after another) and/or in parallel
+   (simultaneously). This pattern utilizes the other 3 patterns to orchestrate
+   multiple experiments that may depend on each other. An example use case
+   is the creation of a certain material using physical and/or chemical
+   processes (e.g., catalysis) and the analysis of the properties of the
+   created material in multiple experiments (e.g., spectroscopy and stress
+   testing).
 
 The features of these science use case strategic patterns and their
 relationships are compared in
-:numref:`intersect:arch:pat:catalog:strategic:relationships`
+:numref:`intersect:arch:pat:catalog:strategic:relationships`.
 
 .. table:: Feature comparison and relationships of the science use case
            strategic patterns

--- a/pat/index.rst
+++ b/pat/index.rst
@@ -3,11 +3,10 @@
 Science Use Case Design Patterns
 ################################
 
-The science use case design patterns of the :term:`INTERSECT` Open Architecture
-Specification identify and abstract the involved hardware/software components
-and their interactions in terms of control, work and data flow. The
-:ref:`intersect:arch:pat:anatomy` is defined in a loop control problem
-paradigm.
+The science use case design patterns identify and abstract the involved
+hardware/software components and their interactions in terms of control,
+work and data flow. The :ref:`intersect:arch:pat:anatomy` is defined in
+a loop control problem paradigm.
 
 At the moment, the :ref:`intersect:arch:pat:catalog` defines two classes of
 patterns: :ref:`intersect:arch:pat:catalog:strategic` with high-level solution
@@ -16,10 +15,12 @@ granularity and :ref:`intersect:arch:pat:catalog:architectural` with more
 specific solution methods using hardware and software architecture features at
 a finer granularity. The classification scheme itself is open for extension,
 such as for adding new patterns for each class or new classes entirely. For
-example, a new class may map the existing patterns to other workflow
-properties, such as (a) data-intensive, (b) time-sensitive and (c) long-term
-experiment campaigns (woprkflow execution patterns defined by the :term:`IRI`
-Architecture Blueprint Activity :cite:`IRI:2023`).
+example, a new class may map the existing patterns to
+:ref:`intersect:arch:sos:logical:systems:ors:workflows:pattern`, such as the
+:ref:`intersect:arch:iri:patterns:time`,
+:ref:`intersect:arch:iri:patterns:data` and
+:ref:`intersect:arch:iri:patterns:long` patterns defined by the
+:ref:`intersect:arch:iri` Blueprint Activity :cite:`IRI:2023`.
 
 :ref:`intersect:arch:pat:solutions` requires dissecting a science use case
 by the open or closed loop control problem or problems it contains.

--- a/pat/introduction.rst
+++ b/pat/introduction.rst
@@ -33,6 +33,9 @@ system’s flexibility or scalability as well as consider implementation issues.
 Design patterns must address a specific problem at hand, and yet must be
 general enough to remain relevant to future requirements of systems.
 
+Software Design Patterns
+========================
+
 In the domain of software design, patterns were introduced in an effort to
 create reusable solutions in the design of software and bring discipline to the
 art of programming. The intent of software design patterns isn’t to provide a
@@ -97,6 +100,8 @@ functionality of a workflow and certain common execution patterns, such as data
 movement and data analysis steps. Similar workflows execution patterns, not
 design patterns, have been recently proposed for instrument science
 :cite:`VESCOVI2022100606`. The :ref:`intersect:arch:iri` Blueprint Activity
-:cite:`IRI:2023` has recently defined execution patterns for scientific
-computational workflows, such as (a) data-intensive, (b) time-sensitive and
-(c) long-term experiment campaigns.
+:cite:`IRI:2023` has recently defined
+:ref:`intersect:arch:sos:logical:systems:ors:workflows:pattern` for scientific
+computational workflows, such as :ref:`intersect:arch:iri:patterns:time`,
+:ref:`intersect:arch:iri:patterns:data` and
+:ref:`intersect:arch:iri:patterns:long`.

--- a/pat/introduction.rst
+++ b/pat/introduction.rst
@@ -33,6 +33,8 @@ system’s flexibility or scalability as well as consider implementation issues.
 Design patterns must address a specific problem at hand, and yet must be
 general enough to remain relevant to future requirements of systems.
 
+.. _intersect:arch:pat:introduction:software:
+
 Software Design Patterns
 ========================
 

--- a/pat/solutions/compositions.rst
+++ b/pat/solutions/compositions.rst
@@ -13,7 +13,8 @@ strategic pattern instead. Similarly, the
 uses the :ref:`intersect:arch:pat:catalog:strategic:control` strategic pattern,
 but could use the :ref:`intersect:arch:pat:catalog:strategic:steering` strategic
 pattern, the :ref:`intersect:arch:pat:catalog:strategic:design` strategic
-pattern, or a combination of :ref:`intersect:arch:pat:catalog:strategic:control`,
+pattern, or a combination of
+:ref:`intersect:arch:pat:catalog:strategic:control`,
 :ref:`intersect:arch:pat:catalog:strategic:steering`, and
 :ref:`intersect:arch:pat:catalog:strategic:design` strategic patterns instead.
 This composition of strategic patterns is then also reflected in composition
@@ -33,22 +34,27 @@ loops that are independent from each other. They may operate with different
 timing requirements, perform analysis on different computational resources and
 modify different parameters independent from each other.
 
+.. _intersect:arch:pat:solutions:compositions:example:
+
+Example
+=======
+
 The following example illustrates the composition of science use case design
 patterns. In this solution, there is a control loop for
 :ref:`intersect:arch:pat:catalog:strategic:steering` to change parameters based
 on observation as the experiment is progressing. There is also a second control
 loop for :ref:`intersect:arch:pat:catalog:strategic:design` to change the
-Experiment Plan based on the prior experiment result after each experiment.
+experiment plan based on the prior experiment result after each experiment.
 :numref:`intersect:arch:pat:compositions:strategic` illustrates the involved
 components and control/data flow of the
 :ref:`intersect:arch:pat:catalog:strategic:steering` and the
 :ref:`intersect:arch:pat:catalog:strategic:design` strategic pattern
-composition. The Experiment Design Plan and the Experiment Planner are exclusive
-parts of the :ref:`intersect:arch:pat:catalog:strategic:design` strategic
-pattern, while the other components are part of the
+composition. The Experiment Design Plan and the experiment planner are
+exclusive parts of the :ref:`intersect:arch:pat:catalog:strategic:design`
+strategic pattern, while the other components are part of the
 :ref:`intersect:arch:pat:catalog:strategic:steering` strategic pattern that the
-:ref:`intersect:arch:pat:catalog:strategic:design` strategic pattern is using as
-its experiment to control from an Experiment Plan perspective.
+:ref:`intersect:arch:pat:catalog:strategic:design` strategic pattern is using
+as its experiment to control from an experiment plan perspective.
 
 .. figure:: compositions/strategic.png
    :name: intersect:arch:pat:compositions:strategic
@@ -63,15 +69,15 @@ In the given science use case example, the
 :ref:`intersect:arch:pat:catalog:strategic:steering` utilizes a local shared
 storage device, such as a small :term:`NAS`, for all sensor data and its
 analysis results. It also relies on a local computational resource, such as an
-NVIDIA Jetson Nano, for analysis and decision making. The
+NVIDIA Jetson Nano computer, for analysis and decision making. The
 :ref:`intersect:arch:pat:catalog:strategic:design` transfers the sensor data of
 the entire experiment from the shared storage device to a remote analyzer, such
-as an NVIDIA DGX system. Its analysis results are evaluated and a new experiment
-plan is created by the Controller on a desktop system running a :term:`GUI`. The
-corresponding involved components and control/data flow of the
+as an NVIDIA DGX computer. Its analysis results are evaluated and a new
+experiment plan is created by the Controller on a desktop computer running a
+:term:`GUI`. The corresponding involved components and control/data flow of the
 :ref:`intersect:arch:pat:catalog:architectural:local_steering` and the
-:ref:`intersect:arch:pat:catalog:architectural:distributed_design` architectural
-pattern composition is shown in
+:ref:`intersect:arch:pat:catalog:architectural:distributed_design`
+architectural pattern composition is shown in
 :numref:`intersect:arch:pat:compositions:architectural`.
 
 .. figure:: compositions/architectural.png
@@ -89,6 +95,6 @@ same physical components, such as when different control loops use the same
 storage device or the same computational resource for analysis and/or control.
 For example, separate controllers for different
 :ref:`intersect:arch:pat:catalog:strategic:steering` control loops may use
-exactly the same physical component, such as a Raspberry Pi, for storing and
-analyzing sensor data and for issuing different, non-conflicting control
-commands to a robot.
+exactly the same physical component, such as a Raspberry Pi computer, for
+storing and analyzing sensor data and for issuing different, non-conflicting
+control commands to a robot.

--- a/pat/solutions/guide.rst
+++ b/pat/solutions/guide.rst
@@ -101,7 +101,7 @@ Which strategic pattern?
    strategic pattern is employed (see
    :ref:`intersect:arch:pat:solutions:compositions`).
 
-What is local? What is remote?:
+What is local? What is remote?
    The architectural science use case design patterns distinguish between local
    and remote components based on communication delay. Any potentially
    significant communication delay to a component makes it a remote component.

--- a/pat/solutions/index.rst
+++ b/pat/solutions/index.rst
@@ -4,7 +4,7 @@ Building Solutions using Science Use Case Design Patterns
 =========================================================
 
 The patterns detailed in the :ref:`intersect:arch:pat:catalog` focus on the
-inherent open or closed loop control problem as a common problem to\ be solved
+inherent open or closed loop control problem as a common problem to be solved
 in reducing human-in-the-loop requirements with machine-in-the-loop
 capabilities. Scientific instruments, robot-controlled laboratories and
 edge/center computing/data resources are connected in a loop control to enable
@@ -32,7 +32,7 @@ including individual decision parameters.
 complete solutions.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :name: intersect:arch:pat:solutions:toc
    :caption: Creating Solutions with Design Patterns for Science Use Cases
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=4.2.0
+sphinx>=4.2.0,<8.0.0
 recommonmark
 docutils
 sphinx-rtd-theme


### PR DESCRIPTION
- Reference figures by number, not name
- Reference the proper parts of the IRI patterns
- Fixed typos
- Some reformatting
- Added subsections where needed