### PR TITLE
add PDF generation support to doc build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,11 +16,17 @@ build:
   #
   apt_packages:
     - plantuml
+    - inkscape
 
 sphinx:
   configuration: conf.py
   # TODO: Fail on all warning to avoid broken references
   #fail_on_warning: true
+
+# Build documentation in additional formats
+formats:
+  - htmlzip
+  - pdf
 
 python:
    install:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ help:
 clean:
 	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+pdf: latexpdf
+
+latexpdf:
+	@$(SPHINXBUILD) -b latex "$(SOURCEDIR)" "$(BUILDDIR)/latex" $(SPHINXOPTS) $(O)
+	@echo "Running LaTeX files through pdflatex..."
+	$(MAKE) -C "$(BUILDDIR)/latex" LATEXMKOPTS="-interaction=nonstopmode" all-pdf
+
 #.PHONY: help Makefile
 #
 ## Catch-all target: route all unknown targets to Sphinx using the new

--- a/README.md
+++ b/README.md
@@ -38,11 +38,23 @@ format and uses [Sphinx](https://www.sphinx-doc.org/) to generate the
    shell$ make
    ```
 
+   To build a PDF version:
+
+   ```
+   shell$ make pdf
+   ```
+
    
  - View in browser (e.g., using ``open`` utility on macOS)
 
    ```
    shell$ open _build/index.html
+   ```
+
+   To view the PDF version:
+
+   ```
+   shell$ open _build/latex/*.pdf
    ```
 
 

--- a/conf.py
+++ b/conf.py
@@ -74,6 +74,27 @@ numfig = True
 # https://www.sphinx-doc.org/en/master/usage/extensions/todo.html
 todo_include_todos = True
 
+# -- Options for LaTeX output ------------------------------------------------
+# LaTeX configuration for PDF generation
+latex_engine = 'pdflatex'
+
+# Configure image converter for SVG files in LaTeX output
+# This tells Sphinx to ignore SVG files that can't be processed by LaTeX
+latex_show_pagerefs = True
+latex_show_urls = 'footnote'
+
+# LaTeX specific configuration
+latex_elements = {}
+
+latex_documents = [
+    ('index',                     # Root document (e.g., 'index' or 'pdf-index')
+     'intersectarchitecture.tex', # Output LaTeX filename (no spaces)
+     project,                     # Document Title (empty uses root doc's title)
+     author,                      # Author names(s)
+     'manual',                    # Document type: ('manual' or 'howto')
+     False)                       # if True, only include docs in toctree
+]
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/conf.py
+++ b/conf.py
@@ -55,7 +55,7 @@ html_context = {
 # ones.
 import sphinx_rtd_theme
 extensions = ['recommonmark', "sphinx_rtd_theme", 'sphinxcontrib.bibtex',
-              'sphinx.ext.todo','sphinxcontrib.plantuml','sphinxcontrib.mermaid', 'sphinxcontrib.youtube']
+              'sphinx.ext.todo','sphinxcontrib.plantuml','sphinxcontrib.mermaid', 'sphinxcontrib.youtube','sphinxcontrib.inkscapeconverter']
 bibtex_bibfiles = ['bibliography.bib', 'publications.bib']
 bibtex_default_style = 'unsrt'
 bibtex_reference_style = 'label'
@@ -129,3 +129,12 @@ rst_prolog = f"""
 
 
 """
+
+latex_elements = {
+    # Fix the "too deeply nested" LaTeX error.
+    'maxlistdepth': '99', # Or a sufficiently large number
+    # Temporarily fix the hyperfer warnings by disabling hyperrefs.
+#    'preamble': r'''
+#    \renewcommand{\hyperref}[2][]{#2}
+#    '''
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sphinxcontrib-bibtex
 sphinxcontrib-plantuml
 sphinxcontrib-mermaid
 sphinxcontrib-youtube
+sphinxcontrib-svg2pdfconverter

--- a/sos/logical/resilience/index.rst
+++ b/sos/logical/resilience/index.rst
@@ -141,7 +141,7 @@ adopted, as they are universally applicable.
          high-performance computing
 
    Classification of resilience design patterns in the context of
-   high-performance computing :cite:`engelmann22rdp-20`
+   high-performance computing
 
 The :ref:`intersect:arch:sos:logical:resilience:patterns:toc` provides a
 variety of solutions to problems that repeatedly appear in the design of error


### PR DESCRIPTION
- Enable PDF format in ReadTheDocs configuration
- Add LaTeX/PDF build targets to Makefile
- Configure LaTeX engine and options in Sphinx conf.py
- PDF builds will be generated automatically alongside HTML
- Update README